### PR TITLE
Changing to mariadb so we don't need an ARM branch anymore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,15 +15,15 @@ services:
     restart: unless-stopped
 
   db:
-    image: mysql:5.7
+    image: mariadb
+    restart: unless-stopped
     container_name: academy-mysql
-    ports:
-      - 127.0.0.1:3306:3306
-    volumes:
-      - ./db:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: password
-    restart: unless-stopped
+    volumes:
+      - ./db:/var/lib/mysql
+    ports:
+      - 3306:3306
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin


### PR DESCRIPTION
Gone will be the days where we need to get students to check if they have intel/m1/m2, checkout the apple branch etc. This branch should work on all macs