### PR TITLE
Switching to PHP 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # iO Academy Docker image
 
-***!!!  Note:*** **If you are using an M1 chip, use [the M1 branch of these instructions](https://github.com/iO-Academy/docker-image/tree/apple-m1).**  ***!!!***
-
 
 Start by creating the following directory
 

--- a/build/php/Dockerfile
+++ b/build/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm
+FROM php:8.1-fpm
 RUN apt-get update \
     && apt-get install -y zlib1g-dev libxml2-dev libssl-dev libzip-dev
 RUN docker-php-ext-install -j$(nproc) pdo_mysql

--- a/build/php/Dockerfile
+++ b/build/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.2-fpm
 RUN apt-get update \
     && apt-get install -y zlib1g-dev libxml2-dev libssl-dev libzip-dev
 RUN docker-php-ext-install -j$(nproc) pdo_mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,15 +15,15 @@ services:
     restart: unless-stopped
 
   db:
-    image: mysql:5.7
+    image: mariadb
+    restart: unless-stopped
     container_name: academy-mysql
-    ports:
-      - 127.0.0.1:3306:3306
-    volumes:
-      - ./db:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: password
-    restart: unless-stopped
+    volumes:
+      - ./db:/var/lib/mysql
+    ports:
+      - 3306:3306
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin


### PR DESCRIPTION
Two changes:

1) Switching to php 8.2
2) Universally switching to mariadb. Have tested on non m1 and it works perfectly, means we don't need to muck around with two branches when setting up docker on student laptops