### PR TITLE
Sdeportkill

### DIFF
--- a/build/php/Dockerfile
+++ b/build/php/Dockerfile
@@ -1,12 +1,13 @@
 FROM php:8.2-fpm
 RUN apt-get update \
-    && apt-get install -y zlib1g-dev libxml2-dev libssl-dev libzip-dev
+    && apt-get install -y zlib1g-dev libxml2-dev libssl-dev libzip-dev psmisc
 RUN docker-php-ext-install -j$(nproc) pdo_mysql
 RUN docker-php-ext-install -j$(nproc) zip
 RUN docker-php-ext-install -j$(nproc) bcmath
 RUN docker-php-ext-install -j$(nproc) calendar
 RUN docker-php-ext-install -j$(nproc) soap
 RUN docker-php-ext-install -j$(nproc) intl
+
 
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer

--- a/build/scripts/student/stop.sh
+++ b/build/scripts/student/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+# Command to kill processes running on a specific port
+# For when slim/laravel gets stuck running
+
+# Uses the fuser -k command to kill the process
+# The '> /dev/null 2>&1' portion of the command hides the output from fuser,
+# which can often have a bunch of meaningless permission errors
+DOCKER_COMMAND="docker exec -ti academy-php fuser -k $*/tcp > /dev/null 2>&1"
+eval $DOCKER_COMMAND

--- a/build/scripts/trainer/stop.sh
+++ b/build/scripts/trainer/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+# Command to kill processes running on a specific port
+# For when slim/laravel gets stuck running
+
+# Uses the fuser -k command to kill the process
+# The '> /dev/null 2>&1' portion of the command hides the output from fuser,
+# which can often have a bunch of meaningless permission errors
+DOCKER_COMMAND="docker exec -ti academy-php fuser -k $*/tcp > /dev/null 2>&1"
+eval $DOCKER_COMMAND

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,25 @@ else
   fi
 fi
 
+echo "STOP: Attempting to install the stop.sh helper script"
+
+STOP_FILE=~/stop.sh
+
+if [ -f "$STOP_FILE" ]; then
+  echo_warning "STOP: Looks like you already have the stop.sh script installed"
+else
+  cp "$SCRIPT_PATH/stop.sh" ~
+  chmod +x ~/stop.sh
+  if [ -x "$STOP_FILE" ]; then
+    echo "alias stop='~/stop.sh'" >> ~/.zshrc
+    INSTALLED=true
+    echo_success "STOP: stop.sh installed successfully"
+  else
+    ERROR=true
+    echo_fail "STOP: Error unable to make stop.sh executable"
+  fi
+fi
+
 # If any of the installs ran, use exec to reload zsh
 if $INSTALLED; then
     echo_success "Install complete" true


### PR DESCRIPTION
A new sh file to kill processes running on a given port. Useful for when students get slim or laravel stuck running.

Changes:
- php dockerfile: Installing psmisc which gives you the fuser command - this is needed because debian (which comes with the php image) doesn't have any of the commands installed you need to do this
- Adding a new stop.sh script (both student and trainer versions, both of which are currently exactly the same)
- Adding a new step to the instal.sh file

Usage:
Run `stop <port>` eg `stop 8080`

Note: Because this change updates a dockerfile, you will need to do a `docker-compose up --force-recreate --build`