### PR TITLE
Portkill

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ All other details as above.
 
 ## PHPMyAdmin
 
-To use PHPMyAdmin to adminster databases open [http://localhost:8081/](http://localhost:8081/) and use the same credentials as above to log in (although there is no need to enter a host)
+To use PHPMyAdmin to adminster databases open [http://localhost:8086/](http://localhost:8086/) and use the same credentials as above to log in (although there is no need to enter a host)
 
 ## Mongo Connection
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ const url = 'mongodb://localhost:27017/{DBNAME}';
 const db = await MongoClient.connect(url)
 ```
 
+## Stopping processes running on a specific port
+
+To kill a process using a port, for example a Slim app, you can run the following command:
+
+```bash
+stop 8080
+```
+
 ## Execute Commands
 
 To execute arbitrary php against your box you can run the following command:

--- a/build/php/Dockerfile
+++ b/build/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.2-fpm
 RUN apt-get update \
-    && apt-get install -y zlib1g-dev libxml2-dev libssl-dev libzip-dev
+    && apt-get install -y zlib1g-dev libxml2-dev libssl-dev libzip-dev psmisc
 RUN docker-php-ext-install -j$(nproc) pdo_mysql
 RUN docker-php-ext-install -j$(nproc) zip
 RUN docker-php-ext-install -j$(nproc) bcmath

--- a/build/scripts/student/stop.sh
+++ b/build/scripts/student/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+# Command to kill processes running on a specific port
+# For when slim/laravel gets stuck running
+
+# Uses the fuser -k command to kill the process
+# The '> /dev/null 2>&1' portion of the command hides the output from fuser,
+# which can often have a bunch of meaningless permission errors
+DOCKER_COMMAND="docker exec -ti academy-php fuser -k $*/tcp > /dev/null 2>&1"
+eval $DOCKER_COMMAND

--- a/build/scripts/trainer/stop.sh
+++ b/build/scripts/trainer/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+# Command to kill processes running on a specific port
+# For when slim/laravel gets stuck running
+
+# Uses the fuser -k command to kill the process
+# The '> /dev/null 2>&1' portion of the command hides the output from fuser,
+# which can often have a bunch of meaningless permission errors
+DOCKER_COMMAND="docker exec -ti academy-php fuser -k $*/tcp > /dev/null 2>&1"
+eval $DOCKER_COMMAND

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       PMA_ARBITRARY: 1
     restart: unless-stopped
     ports:
-      - 8081:80
+      - 8086:80
 
 
   mongodb:

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,25 @@ else
   fi
 fi
 
+echo "STOP: Attempting to install the stop.sh helper script"
+
+STOP_FILE=~/stop.sh
+
+if [ -f "$STOP_FILE" ]; then
+  echo_warning "STOP: Looks like you already have the stop.sh script installed"
+else
+  cp "$SCRIPT_PATH/stop.sh" ~
+  chmod +x ~/stop.sh
+  if [ -x "$STOP_FILE" ]; then
+    echo "alias stop='~/stop.sh'" >> ~/.zshrc
+    INSTALLED=true
+    echo_success "STOP: stop.sh installed successfully"
+  else
+    ERROR=true
+    echo_fail "STOP: Error unable to make stop.sh executable"
+  fi
+fi
+
 # If any of the installs ran, use exec to reload zsh
 if $INSTALLED; then
     echo_success "Install complete" true


### PR DESCRIPTION
A new sh file to kill processes running on a given port. Useful for when students get slim stuck running.

Changes:

*   php dockerfile: Installing psmisc which gives you the fuser command - this is needed because debian (which comes with the php image) doesn't have any of the commands installed you need to do this
*   Adding a new stop.sh script (both student and trainer versions, both of which are currently exactly the same)
*   Adding a new step to the instal.sh file

Usage:  
Run `stop <port>` eg `stop 8080`

Note: Because this change updates a dockerfile, you will need to do a `docker-compose up --force-recreate --build`